### PR TITLE
fix: allow arbitrary location categories

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -2,6 +2,14 @@ export interface Location {
   name: string;
   description: string;
   coordinates: [number, number];
-  type: 'food' | 'clothing' | 'shelter';
+  /**
+   * Category of location. Historically only "food", "clothing" and "shelter"
+   * were allowed, but the dataset now includes many more categories (e.g.
+   * community, youth, mental health).  Using a narrow union here caused
+   * TypeScript to reject valid entries from `data/locations.json`, preventing
+   * the application from compiling when new categories were added.  Allow any
+   * string to ensure the type stays in sync with the data source.
+   */
+  type: string;
   address: string;
 }


### PR DESCRIPTION
## Summary
- allow location `type` to be any string so dataset categories compile cleanly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689879e5c970833392b8c3cdd90f5422