### PR TITLE
Add unit tests for useLocations composable

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "node --experimental-strip-types --loader ./tests/loader.mjs --test tests/useLocations.spec.ts"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",

--- a/tests/loader.mjs
+++ b/tests/loader.mjs
@@ -1,0 +1,19 @@
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('~~/')) {
+    const resolved = pathToFileURL(path.join(rootDir, specifier.slice(3))).href;
+    return { url: resolved, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+  if (url.endsWith('/data/locations.json')) {
+    return { format: 'module', source: 'export default [];', shortCircuit: true };
+  }
+  return nextLoad(url, context);
+}

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ref } from 'vue';
+
+// Ensure alias `~~` points to project root so imports in composables work
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const aliasDir = path.join(rootDir, 'node_modules', '~~');
+try {
+  fs.statSync(aliasDir);
+} catch {
+  fs.symlinkSync(rootDir, aliasDir, 'dir');
+}
+
+// Provide Vue's ref globally to match Nuxt auto-import behavior
+(globalThis as any).ref = ref;
+
+const { useLocations } = await import('../app/composables/useLocations.ts');
+
+function createFlyToSpy() {
+  const calls: any[] = [];
+  const flyTo = (...args: any[]) => {
+    calls.push(args);
+  };
+  return { flyTo, calls };
+}
+
+test('focus sets selected and calls flyTo with location coordinates', () => {
+  const { flyTo, calls } = createFlyToSpy();
+  (globalThis as any).useMapbox = (_id: string, cb: (map: any) => void) => {
+    cb({ flyTo });
+  };
+
+  const { selected, focus } = useLocations();
+  const location = { name: 'Test', description: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
+
+  focus(location);
+
+  assert.deepEqual(selected.value, location);
+  assert.deepEqual(calls[0][0], { center: location.coordinates, zoom: 10 });
+});
+
+test('reset clears selected and calls flyTo with default center', () => {
+  const { flyTo, calls } = createFlyToSpy();
+  (globalThis as any).useMapbox = (_id: string, cb: (map: any) => void) => {
+    cb({ flyTo });
+  };
+
+  const { selected, focus, reset } = useLocations();
+  const location = { name: 'Test', description: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
+
+  focus(location);
+  calls.length = 0; // clear previous flyTo call
+
+  reset();
+
+  assert.equal(selected.value, null);
+  assert.deepEqual(calls[0][0], { center: [8.49, 64.63], zoom: 4.38 });
+});


### PR DESCRIPTION
## Summary
- add Node test verifying useLocations `focus` and `reset` behaviors
- provide custom loader to resolve Nuxt aliases during tests
- wire up `npm test` script using Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987b3a75d08333b5825627172ffc90