### PR TITLE
Add filtering, search, and organizations list

### DIFF
--- a/app/components/LocationList.vue
+++ b/app/components/LocationList.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
-const { locations, selected, focus, reset } = useLocations();
+const { locations, selected, focus, reset, searchQuery, filterType } = useLocations();
+
+const typeOptions = [
+  { value: '', label: 'Tümü' },
+  { value: 'foodbank', label: 'Yiyecek yardımı' },
+  { value: 'health', label: 'Sağlık yardımı' },
+  { value: 'shelter', label: 'Konaklama' },
+  { value: 'community', label: 'Topluluk' },
+];
 </script>
 
 <template>
   <div>
-    <div class="p-4 border-b border-gray-200">
+    <div class="p-4 border-b border-gray-200 space-y-1">
       <h1 class="text-xl font-bold text-gray-900">HELP MAP</h1>
+      <NuxtLink to="/organizations" class="text-sm text-indigo-600 hover:underline">
+        Yardım Kuruluşları
+      </NuxtLink>
     </div>
 
     <div v-if="selected" class="p-4 space-y-3">
@@ -25,18 +36,45 @@ const { locations, selected, focus, reset } = useLocations();
       </p>
     </div>
 
-    <ul v-else class="divide-y divide-gray-100">
-      <li v-for="location in locations" :key="location.name" @click="focus(location)" class="p-4 cursor-pointer border-b border-black/10 space-y-3 hover:bg-neutral-100 transition">
-        <div>
-          <h3 class="text-base font-semibold text-gray-800">{{ location.name }}</h3>
-          <p class="text-sm text-gray-500">{{ location.address }}</p>
-        </div>
-        <div class="flex items-center space-x-2">
-          <p class="text-sm text-green-600 font-semibold">Open</p>
-          <span class="text-gray-400">•</span>
-          <p class="text-sm text-gray-500">Today until 6:30pm</p>
-        </div>
-      </li>
-    </ul>
+    <div v-else>
+      <div class="p-4 space-y-2">
+        <label for="search" class="sr-only">Ara</label>
+        <input
+          id="search"
+          v-model="searchQuery"
+          type="text"
+          placeholder="Ara..."
+          class="w-full p-2 border rounded"
+        />
+        <label for="filter" class="sr-only">Tür filtresi</label>
+        <select
+          id="filter"
+          v-model="filterType"
+          class="w-full p-2 border rounded"
+        >
+          <option v-for="option in typeOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+      <ul class="divide-y divide-gray-100">
+        <li
+          v-for="location in locations"
+          :key="location.name"
+          @click="focus(location)"
+          class="p-4 cursor-pointer border-b border-black/10 space-y-3 hover:bg-neutral-100 transition"
+        >
+          <div>
+            <h3 class="text-base font-semibold text-gray-800">{{ location.name }}</h3>
+            <p class="text-sm text-gray-500">{{ location.address }}</p>
+          </div>
+          <div class="flex items-center space-x-2">
+            <p class="text-sm text-green-600 font-semibold">Open</p>
+            <span class="text-gray-400">•</span>
+            <p class="text-sm text-gray-500">Today until 6:30pm</p>
+          </div>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -1,8 +1,22 @@
 import type { Location } from '~~/types';
-import locations from '~~/data/locations.json';
+import locationsData from '~~/data/locations.json';
 
 export function useLocations() {
+  const allLocations = locationsData as Location[];
   const selected = ref<Location | null>(null);
+  const searchQuery = ref('');
+  const filterType = ref('');
+
+  const locations = computed(() =>
+    allLocations.filter(l => {
+      const query = searchQuery.value.toLowerCase();
+      const matchesQuery = !query ||
+        [l.name, l.city, l.address, l.description]
+          .some(v => v.toLowerCase().includes(query));
+      const matchesType = !filterType.value || l.type === filterType.value;
+      return matchesQuery && matchesType;
+    })
+  );
 
   function focus(location: Location) {
     selected.value = location;
@@ -18,5 +32,5 @@ export function useLocations() {
     });
   }
 
-  return { locations, selected, focus, reset };
+  return { locations, selected, focus, reset, searchQuery, filterType };
 }

--- a/app/pages/organizations.vue
+++ b/app/pages/organizations.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import organizations from '~/data/organizations.json';
+</script>
+
+<template>
+  <div class="p-4 space-y-4">
+    <h1 class="text-xl font-bold">Norveç'teki Yardım Kuruluşları</h1>
+    <ul class="space-y-3">
+      <li
+        v-for="org in organizations"
+        :key="org.name"
+        class="p-4 border rounded"
+      >
+        <h2 class="font-semibold">{{ org.name }}</h2>
+        <p class="text-sm text-gray-700">{{ org.description }}</p>
+        <a
+          :href="org.website"
+          target="_blank"
+          rel="noopener"
+          class="text-indigo-600 underline"
+        >Web sitesi</a>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/data/organizations.json
+++ b/data/organizations.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Kirkens Bymisjon",
+    "description": "Community services and support across Norway",
+    "website": "https://kirkensbymisjon.no"
+  },
+  {
+    "name": "Frelsesarmeen",
+    "description": "The Salvation Army in Norway providing food, shelter and community assistance",
+    "website": "https://frelsesarmeen.no"
+  },
+  {
+    "name": "Røde Kors",
+    "description": "Norwegian Red Cross offering health and emergency help",
+    "website": "https://www.rodekors.no"
+  }
+]

--- a/tests/loader.mjs
+++ b/tests/loader.mjs
@@ -13,7 +13,15 @@ export async function resolve(specifier, context, nextResolve) {
 
 export async function load(url, context, nextLoad) {
   if (url.endsWith('/data/locations.json')) {
-    return { format: 'module', source: 'export default [];', shortCircuit: true };
+    const sample = [
+      { name: 'Oslo Food', description: '', city: 'Oslo', coordinates: [0, 0], type: 'foodbank', address: '' },
+      { name: 'Bergen Health', description: '', city: 'Bergen', coordinates: [0, 0], type: 'health', address: '' },
+    ];
+    return {
+      format: 'module',
+      source: 'export default ' + JSON.stringify(sample) + ';',
+      shortCircuit: true,
+    };
   }
   return nextLoad(url, context);
 }

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 // Ensure alias `~~` points to project root so imports in composables work
 const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
@@ -15,6 +15,7 @@ try {
 
 // Provide Vue's ref globally to match Nuxt auto-import behavior
 (globalThis as any).ref = ref;
+(globalThis as any).computed = computed;
 
 const { useLocations } = await import('../app/composables/useLocations.ts');
 
@@ -33,7 +34,7 @@ test('focus sets selected and calls flyTo with location coordinates', () => {
   };
 
   const { selected, focus } = useLocations();
-  const location = { name: 'Test', description: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
+  const location = { name: 'Test', description: '', city: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
 
   focus(location);
 
@@ -48,7 +49,7 @@ test('reset clears selected and calls flyTo with default center', () => {
   };
 
   const { selected, focus, reset } = useLocations();
-  const location = { name: 'Test', description: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
+  const location = { name: 'Test', description: '', city: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
 
   focus(location);
   calls.length = 0; // clear previous flyTo call
@@ -57,4 +58,12 @@ test('reset clears selected and calls flyTo with default center', () => {
 
   assert.equal(selected.value, null);
   assert.deepEqual(calls[0][0], { center: [8.49, 64.63], zoom: 4.38 });
+});
+
+test('filters by query and type', () => {
+  const { locations, searchQuery, filterType } = useLocations();
+  searchQuery.value = 'Bergen';
+  filterType.value = 'health';
+  assert.equal(locations.value.length, 1);
+  assert.equal(locations.value[0].name, 'Bergen Health');
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,7 @@
 export interface Location {
   name: string;
   description: string;
+  city: string;
   coordinates: [number, number];
   /**
    * Category of location. Historically only "food", "clothing" and "shelter"
@@ -12,4 +13,10 @@ export interface Location {
    */
   type: string;
   address: string;
+}
+
+export interface Organization {
+  name: string;
+  description: string;
+  website: string;
 }


### PR DESCRIPTION
## Summary
- enable search and type-based filtering for locations
- add organizations page listing major Norwegian charities
- expose types for new data fields and organizations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c646cbe48333b9b0e6ac24b4c1e0