### PR TITLE
Enable filtering by organization

### DIFF
--- a/app/components/LocationList.vue
+++ b/app/components/LocationList.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
-const { locations, selected, focus, reset, searchQuery, filterType, filterOrg, types, organizations } = useLocations();
-
-const typeOptions = computed(() => [
-  { value: '', label: 'Tümü' },
-  ...types.value.map(t => ({
-    value: t,
-    label: t.charAt(0).toUpperCase() + t.slice(1)
-  }))
-]);
-
-const organizationOptions = computed(() => [
-  { value: '', label: 'Tümü' },
-  ...organizations.value.map(o => ({ value: o, label: o }))
-]);
+const {
+  locations,
+  selected,
+  focus,
+  reset,
+  searchQuery,
+  filterTypes,
+  filterOrgs,
+  types,
+  organizations,
+} = useLocations();
 </script>
 
 <template>
@@ -43,35 +40,53 @@ const organizationOptions = computed(() => [
     </div>
 
     <div v-else>
-      <div class="p-4 flex flex-col gap-2 sm:flex-row" role="search">
-        <label for="search" class="sr-only">Ara</label>
-        <input
-          id="search"
-          v-model="searchQuery"
-          type="text"
-          placeholder="Ara..."
-          class="w-full p-2 border rounded flex-1"
-        />
-        <label for="type-filter" class="sr-only">Tür filtresi</label>
-        <select
-          id="type-filter"
-          v-model="filterType"
-          class="w-full p-2 border rounded flex-1"
-        >
-          <option v-for="option in typeOptions" :key="option.value" :value="option.value">
-            {{ option.label }}
-          </option>
-        </select>
-        <label for="org-filter" class="sr-only">Kuruluş filtresi</label>
-        <select
-          id="org-filter"
-          v-model="filterOrg"
-          class="w-full p-2 border rounded flex-1"
-        >
-          <option v-for="option in organizationOptions" :key="option.value" :value="option.value">
-            {{ option.label }}
-          </option>
-        </select>
+      <div class="p-4 space-y-4" role="search">
+        <div>
+          <label for="search" class="block text-sm font-medium">Ara</label>
+          <input
+            id="search"
+            v-model="searchQuery"
+            type="text"
+            placeholder="Ara..."
+            class="w-full p-2 border rounded"
+          />
+        </div>
+        <fieldset>
+          <legend class="block text-sm font-medium mb-1">Tür</legend>
+          <div class="flex flex-wrap gap-2">
+            <label
+              v-for="type in types"
+              :key="type"
+              class="inline-flex items-center gap-1 text-sm"
+            >
+              <input
+                type="checkbox"
+                :value="type"
+                v-model="filterTypes"
+                class="w-4 h-4"
+              />
+              {{ type.charAt(0).toUpperCase() + type.slice(1) }}
+            </label>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend class="block text-sm font-medium mb-1">Kuruluş</legend>
+          <div class="flex flex-wrap gap-2">
+            <label
+              v-for="org in organizations"
+              :key="org"
+              class="inline-flex items-center gap-1 text-sm"
+            >
+              <input
+                type="checkbox"
+                :value="org"
+                v-model="filterOrgs"
+                class="w-4 h-4"
+              />
+              {{ org }}
+            </label>
+          </div>
+        </fieldset>
       </div>
       <ul class="divide-y divide-gray-100">
         <li

--- a/app/components/LocationList.vue
+++ b/app/components/LocationList.vue
@@ -1,15 +1,5 @@
 <script setup lang="ts">
-const {
-  locations,
-  selected,
-  focus,
-  reset,
-  searchQuery,
-  filterTypes,
-  filterOrgs,
-  types,
-  organizations,
-} = useLocations();
+const { locations, selected, focus, reset, searchQuery, filterTypes, filterOrgs, types, organizations } = useLocations();
 </script>
 
 <template>
@@ -19,22 +9,22 @@ const {
     </div>
 
     <div v-if="selected" class="p-4 space-y-3">
-      <button @click="reset" class="text-sm cursor-pointer text-indigo-600 hover:underline">&larr; Geri</button>
+      <button @click="reset" class="text-sm cursor-pointer text-indigo-600 hover:underline">&larr; Back</button>
       <h2 class="text-lg font-semibold">{{ selected.name }}</h2>
       <p class="text-sm text-gray-600">
-        <strong>Açıklama:</strong>
+        <strong>Description:</strong>
         {{ selected.description }}
       </p>
       <p class="text-sm text-gray-600">
-        <strong>Tür:</strong>
+        <strong>Type:</strong>
         {{ selected.type }}
       </p>
       <p class="text-sm text-gray-600">
-        <strong>Kuruluş:</strong>
+        <strong>Organization:</strong>
         {{ selected.organization }}
       </p>
       <p class="text-sm text-gray-600">
-        <strong>Adres:</strong>
+        <strong>Address:</strong>
         {{ selected.address }}
       </p>
     </div>
@@ -42,47 +32,22 @@ const {
     <div v-else>
       <div class="p-4 space-y-4" role="search">
         <div>
-          <label for="search" class="block text-sm font-medium">Ara</label>
-          <input
-            id="search"
-            v-model="searchQuery"
-            type="text"
-            placeholder="Ara..."
-            class="w-full p-2 border rounded"
-          />
+          <input id="search" v-model="searchQuery" type="text" placeholder="Search..." class="w-full p-2 border rounded" />
         </div>
         <fieldset>
-          <legend class="block text-sm font-medium mb-1">Tür</legend>
+          <legend class="block text-sm font-medium mb-1">Type</legend>
           <div class="flex flex-wrap gap-2">
-            <label
-              v-for="type in types"
-              :key="type"
-              class="inline-flex items-center gap-1 text-sm"
-            >
-              <input
-                type="checkbox"
-                :value="type"
-                v-model="filterTypes"
-                class="w-4 h-4"
-              />
+            <label v-for="type in types" :key="type" class="inline-flex items-center gap-1 text-sm">
+              <input type="checkbox" :value="type" v-model="filterTypes" class="w-4 h-4" />
               {{ type.charAt(0).toUpperCase() + type.slice(1) }}
             </label>
           </div>
         </fieldset>
         <fieldset>
-          <legend class="block text-sm font-medium mb-1">Kuruluş</legend>
+          <legend class="block text-sm font-medium mb-1">Organization</legend>
           <div class="flex flex-wrap gap-2">
-            <label
-              v-for="org in organizations"
-              :key="org"
-              class="inline-flex items-center gap-1 text-sm"
-            >
-              <input
-                type="checkbox"
-                :value="org"
-                v-model="filterOrgs"
-                class="w-4 h-4"
-              />
+            <label v-for="org in organizations" :key="org" class="inline-flex items-center gap-1 text-sm">
+              <input type="checkbox" :value="org" v-model="filterOrgs" class="w-4 h-4" />
               {{ org }}
             </label>
           </div>
@@ -93,8 +58,7 @@ const {
           v-for="location in locations"
           :key="location.name"
           @click="focus(location)"
-          class="p-4 cursor-pointer border-b border-black/10 hover:bg-neutral-100 transition space-y-1"
-        >
+          class="p-4 cursor-pointer border-b border-black/10 hover:bg-neutral-100 transition space-y-1">
           <div>
             <h3 class="text-base font-semibold text-gray-800">{{ location.name }}</h3>
             <p class="text-sm text-gray-500">{{ location.address }}</p>

--- a/app/components/LocationList.vue
+++ b/app/components/LocationList.vue
@@ -1,10 +1,23 @@
 <script setup lang="ts">
-const { locations, selected, focus, reset } = useLocations();
+const { locations, selected, focus, reset, searchQuery, filterType, filterOrg, types, organizations } = useLocations();
+
+const typeOptions = computed(() => [
+  { value: '', label: 'Tümü' },
+  ...types.value.map(t => ({
+    value: t,
+    label: t.charAt(0).toUpperCase() + t.slice(1)
+  }))
+]);
+
+const organizationOptions = computed(() => [
+  { value: '', label: 'Tümü' },
+  ...organizations.value.map(o => ({ value: o, label: o }))
+]);
 </script>
 
 <template>
   <div>
-    <div class="p-4 border-b border-gray-200">
+    <div class="p-4 border-b border-gray-200 space-y-1">
       <h1 class="text-xl font-bold text-gray-900">HELP MAP</h1>
     </div>
 
@@ -20,23 +33,63 @@ const { locations, selected, focus, reset } = useLocations();
         {{ selected.type }}
       </p>
       <p class="text-sm text-gray-600">
+        <strong>Kuruluş:</strong>
+        {{ selected.organization }}
+      </p>
+      <p class="text-sm text-gray-600">
         <strong>Adres:</strong>
         {{ selected.address }}
       </p>
     </div>
 
-    <ul v-else class="divide-y divide-gray-100">
-      <li v-for="location in locations" :key="location.name" @click="focus(location)" class="p-4 cursor-pointer border-b border-black/10 space-y-3 hover:bg-neutral-100 transition">
-        <div>
-          <h3 class="text-base font-semibold text-gray-800">{{ location.name }}</h3>
-          <p class="text-sm text-gray-500">{{ location.address }}</p>
-        </div>
-        <div class="flex items-center space-x-2">
-          <p class="text-sm text-green-600 font-semibold">Open</p>
-          <span class="text-gray-400">•</span>
-          <p class="text-sm text-gray-500">Today until 6:30pm</p>
-        </div>
-      </li>
-    </ul>
+    <div v-else>
+      <div class="p-4 flex flex-col gap-2 sm:flex-row" role="search">
+        <label for="search" class="sr-only">Ara</label>
+        <input
+          id="search"
+          v-model="searchQuery"
+          type="text"
+          placeholder="Ara..."
+          class="w-full p-2 border rounded flex-1"
+        />
+        <label for="type-filter" class="sr-only">Tür filtresi</label>
+        <select
+          id="type-filter"
+          v-model="filterType"
+          class="w-full p-2 border rounded flex-1"
+        >
+          <option v-for="option in typeOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+        <label for="org-filter" class="sr-only">Kuruluş filtresi</label>
+        <select
+          id="org-filter"
+          v-model="filterOrg"
+          class="w-full p-2 border rounded flex-1"
+        >
+          <option v-for="option in organizationOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+      <ul class="divide-y divide-gray-100">
+        <li
+          v-for="location in locations"
+          :key="location.name"
+          @click="focus(location)"
+          class="p-4 cursor-pointer border-b border-black/10 hover:bg-neutral-100 transition space-y-1"
+        >
+          <div>
+            <h3 class="text-base font-semibold text-gray-800">{{ location.name }}</h3>
+            <p class="text-sm text-gray-500">{{ location.address }}</p>
+          </div>
+          <div class="flex flex-wrap gap-1">
+            <span class="inline-block text-xs text-indigo-700 bg-indigo-50 px-2 py-0.5 rounded">{{ location.type }}</span>
+            <span class="inline-block text-xs text-green-700 bg-green-50 px-2 py-0.5 rounded">{{ location.organization }}</span>
+          </div>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -5,8 +5,8 @@ export function useLocations() {
   const allLocations = locationsData as Location[];
   const selected = ref<Location | null>(null);
   const searchQuery = ref('');
-  const filterType = ref('');
-  const filterOrg = ref('');
+  const filterTypes = ref<string[]>([]);
+  const filterOrgs = ref<string[]>([]);
 
   const types = computed(() =>
     Array.from(new Set(allLocations.map(l => l.type))).sort()
@@ -21,8 +21,10 @@ export function useLocations() {
       const matchesQuery = !query ||
         [l.name, l.city, l.address, l.description]
           .some(v => v.toLowerCase().includes(query));
-      const matchesType = !filterType.value || l.type === filterType.value;
-      const matchesOrg = !filterOrg.value || l.organization === filterOrg.value;
+      const matchesType =
+        filterTypes.value.length === 0 || filterTypes.value.includes(l.type);
+      const matchesOrg =
+        filterOrgs.value.length === 0 || filterOrgs.value.includes(l.organization);
       return matchesQuery && matchesType && matchesOrg;
     })
   );
@@ -41,5 +43,15 @@ export function useLocations() {
     });
   }
 
-  return { locations, selected, focus, reset, searchQuery, filterType, filterOrg, types, organizations };
+  return {
+    locations,
+    selected,
+    focus,
+    reset,
+    searchQuery,
+    filterTypes,
+    filterOrgs,
+    types,
+    organizations,
+  };
 }

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -1,8 +1,31 @@
 import type { Location } from '~~/types';
-import locations from '~~/data/locations.json';
+import locationsData from '~~/data/locations.json';
 
 export function useLocations() {
+  const allLocations = locationsData as Location[];
   const selected = ref<Location | null>(null);
+  const searchQuery = ref('');
+  const filterType = ref('');
+  const filterOrg = ref('');
+
+  const types = computed(() =>
+    Array.from(new Set(allLocations.map(l => l.type))).sort()
+  );
+  const organizations = computed(() =>
+    Array.from(new Set(allLocations.map(l => l.organization))).sort()
+  );
+
+  const locations = computed(() =>
+    allLocations.filter(l => {
+      const query = searchQuery.value.toLowerCase();
+      const matchesQuery = !query ||
+        [l.name, l.city, l.address, l.description]
+          .some(v => v.toLowerCase().includes(query));
+      const matchesType = !filterType.value || l.type === filterType.value;
+      const matchesOrg = !filterOrg.value || l.organization === filterOrg.value;
+      return matchesQuery && matchesType && matchesOrg;
+    })
+  );
 
   function focus(location: Location) {
     selected.value = location;
@@ -18,5 +41,5 @@ export function useLocations() {
     });
   }
 
-  return { locations, selected, focus, reset };
+  return { locations, selected, focus, reset, searchQuery, filterType, filterOrg, types, organizations };
 }

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -8,23 +8,15 @@ export function useLocations() {
   const filterTypes = ref<string[]>([]);
   const filterOrgs = ref<string[]>([]);
 
-  const types = computed(() =>
-    Array.from(new Set(allLocations.map(l => l.type))).sort()
-  );
-  const organizations = computed(() =>
-    Array.from(new Set(allLocations.map(l => l.organization))).sort()
-  );
+  const types = computed(() => Array.from(new Set(allLocations.map(l => l.type))).sort());
+  const organizations = computed(() => Array.from(new Set(allLocations.map(l => l.organization))).sort());
 
   const locations = computed(() =>
     allLocations.filter(l => {
       const query = searchQuery.value.toLowerCase();
-      const matchesQuery = !query ||
-        [l.name, l.city, l.address, l.description]
-          .some(v => v.toLowerCase().includes(query));
-      const matchesType =
-        filterTypes.value.length === 0 || filterTypes.value.includes(l.type);
-      const matchesOrg =
-        filterOrgs.value.length === 0 || filterOrgs.value.includes(l.organization);
+      const matchesQuery = !query || [l.name, l.city, l.address, l.description].some(v => v.toLowerCase().includes(query));
+      const matchesType = filterTypes.value.length === 0 || filterTypes.value.includes(l.type);
+      const matchesOrg = filterOrgs.value.length === 0 || filterOrgs.value.includes(l.organization);
       return matchesQuery && matchesType && matchesOrg;
     })
   );

--- a/tests/loader.mjs
+++ b/tests/loader.mjs
@@ -13,7 +13,15 @@ export async function resolve(specifier, context, nextResolve) {
 
 export async function load(url, context, nextLoad) {
   if (url.endsWith('/data/locations.json')) {
-    return { format: 'module', source: 'export default [];', shortCircuit: true };
+    const sample = [
+      { name: 'Oslo Food', description: '', city: 'Oslo', coordinates: [0, 0], type: 'foodbank', address: '', organization: 'OrgA' },
+      { name: 'Bergen Health', description: '', city: 'Bergen', coordinates: [0, 0], type: 'health', address: '', organization: 'OrgB' },
+    ];
+    return {
+      format: 'module',
+      source: 'export default ' + JSON.stringify(sample) + ';',
+      shortCircuit: true,
+    };
   }
   return nextLoad(url, context);
 }

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 // Ensure alias `~~` points to project root so imports in composables work
 const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
@@ -15,6 +15,7 @@ try {
 
 // Provide Vue's ref globally to match Nuxt auto-import behavior
 (globalThis as any).ref = ref;
+(globalThis as any).computed = computed;
 
 const { useLocations } = await import('../app/composables/useLocations.ts');
 
@@ -33,7 +34,7 @@ test('focus sets selected and calls flyTo with location coordinates', () => {
   };
 
   const { selected, focus } = useLocations();
-  const location = { name: 'Test', description: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
+  const location = { name: 'Test', description: '', city: '', coordinates: [1, 2] as [number, number], type: 'food', address: '', organization: '' };
 
   focus(location);
 
@@ -48,7 +49,7 @@ test('reset clears selected and calls flyTo with default center', () => {
   };
 
   const { selected, focus, reset } = useLocations();
-  const location = { name: 'Test', description: '', coordinates: [1, 2] as [number, number], type: 'food', address: '' };
+  const location = { name: 'Test', description: '', city: '', coordinates: [1, 2] as [number, number], type: 'food', address: '', organization: '' };
 
   focus(location);
   calls.length = 0; // clear previous flyTo call
@@ -57,4 +58,15 @@ test('reset clears selected and calls flyTo with default center', () => {
 
   assert.equal(selected.value, null);
   assert.deepEqual(calls[0][0], { center: [8.49, 64.63], zoom: 4.38 });
+});
+
+test('filters by query, type, and organization', () => {
+  const { locations, searchQuery, filterType, filterOrg, types, organizations } = useLocations();
+  assert.deepEqual(types.value.sort(), ['foodbank', 'health']);
+  assert.deepEqual(organizations.value.sort(), ['OrgA', 'OrgB']);
+  searchQuery.value = 'Bergen';
+  filterType.value = 'health';
+  filterOrg.value = 'OrgB';
+  assert.equal(locations.value.length, 1);
+  assert.equal(locations.value[0].name, 'Bergen Health');
 });

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -61,12 +61,19 @@ test('reset clears selected and calls flyTo with default center', () => {
 });
 
 test('filters by query, type, and organization', () => {
-  const { locations, searchQuery, filterType, filterOrg, types, organizations } = useLocations();
+  const { locations, searchQuery, filterTypes, filterOrgs, types, organizations } = useLocations();
   assert.deepEqual(types.value.sort(), ['foodbank', 'health']);
   assert.deepEqual(organizations.value.sort(), ['OrgA', 'OrgB']);
   searchQuery.value = 'Bergen';
-  filterType.value = 'health';
-  filterOrg.value = 'OrgB';
+  filterTypes.value = ['health'];
+  filterOrgs.value = ['OrgB'];
   assert.equal(locations.value.length, 1);
   assert.equal(locations.value[0].name, 'Bergen Health');
+});
+
+test('allows selecting multiple types and organizations', () => {
+  const { locations, filterTypes, filterOrgs } = useLocations();
+  filterTypes.value = ['foodbank', 'health'];
+  filterOrgs.value = ['OrgA', 'OrgB'];
+  assert.equal(locations.value.length, 2);
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,18 +1,10 @@
 export interface Location {
   name: string;
   description: string;
-  city: string;
-  coordinates: [number, number];
-  /**
-   * Category of location. Historically only "food", "clothing" and "shelter"
-   * were allowed, but the dataset now includes many more categories (e.g.
-   * community, youth, mental health).  Using a narrow union here caused
-   * TypeScript to reject valid entries from `data/locations.json`, preventing
-   * the application from compiling when new categories were added.  Allow any
-   * string to ensure the type stays in sync with the data source.
-   */
+  organization: string;
   type: string;
   address: string;
-  organization: string;
+  city: string;
+  coordinates: [number, number];
+  source: string;
 }
-

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,7 @@
 export interface Location {
   name: string;
   description: string;
+  city: string;
   coordinates: [number, number];
   /**
    * Category of location. Historically only "food", "clothing" and "shelter"
@@ -12,4 +13,6 @@ export interface Location {
    */
   type: string;
   address: string;
+  organization: string;
 }
+


### PR DESCRIPTION
## Summary
- remove dedicated organizations page and dataset
- add organization-based filtering and display in location list
- extend location type definitions and tests for organization field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c646cbe48333b9b0e6ac24b4c1e0