### PR TITLE
feat: add user geolocation and accessible search

### DIFF
--- a/app/components/LocationList.vue
+++ b/app/components/LocationList.vue
@@ -32,7 +32,14 @@ const { locations, selected, focus, reset, searchQuery, filterTypes, filterOrgs,
     <div v-else>
       <div class="p-4 space-y-4" role="search">
         <div>
-          <input id="search" v-model="searchQuery" type="text" placeholder="Search..." class="w-full p-2 border rounded" />
+          <input
+            id="search"
+            v-model="searchQuery"
+            type="text"
+            placeholder="Search for help..."
+            aria-label="Search for help"
+            class="w-full p-2 border rounded"
+          />
         </div>
         <fieldset>
           <legend class="block text-sm font-medium mb-1">Type</legend>

--- a/app/components/MapView.vue
+++ b/app/components/MapView.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
-const { locations } = useLocations();
+const { locations, locateMe } = useLocations();
 </script>
 
 <template>
-  <MapboxMap
-    map-id="main-map"
-    class="absolute inset-0 w-full h-full"
-    :options="{
-      center: [8.49, 64.63],
-      zoom: 4.38,
-      style: 'mapbox://styles/mapbox/streets-v11',
-    }">
-    <MapboxDefaultMarker v-for="(location, index) in locations" :key="location.name" :marker-id="`marker-${index}`" :lnglat="location.coordinates" />
-  </MapboxMap>
+  <div class="relative w-full h-full">
+    <button
+      @click="locateMe"
+      class="absolute top-2 right-2 z-10 bg-white border border-gray-300 rounded px-3 py-1 text-sm shadow">
+      Locate Me
+    </button>
+    <MapboxMap
+      map-id="main-map"
+      class="absolute inset-0 w-full h-full"
+      :options="{
+        center: [8.49, 64.63],
+        zoom: 4.38,
+        style: 'mapbox://styles/mapbox/streets-v11',
+      }">
+      <MapboxDefaultMarker v-for="(location, index) in locations" :key="location.name" :marker-id="`marker-${index}`" :lnglat="location.coordinates" />
+    </MapboxMap>
+  </div>
 </template>

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -35,11 +35,22 @@ export function useLocations() {
     });
   }
 
+  function locateMe() {
+    if (!('geolocation' in navigator)) return;
+    navigator.geolocation.getCurrentPosition(pos => {
+      const { latitude, longitude } = pos.coords;
+      useMapbox('main-map', map => {
+        map?.flyTo({ center: [longitude, latitude], zoom: 12 });
+      });
+    });
+  }
+
   return {
     locations,
     selected,
     focus,
     reset,
+    locateMe,
     searchQuery,
     filterTypes,
     filterOrgs,


### PR DESCRIPTION
## Summary
- allow centering map on the user's current position via a new "Locate Me" button
- expose a `locateMe` helper in the locations composable
- improve search accessibility with clearer placeholder and label

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4cda77e0833386f4769b87869122