### PR TITLE
Refactor locations composable for Nuxt 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@
 
 Help Map is a web application developed by Code for Norway to assist individuals in need across Norway, such as the homeless, refugees, or those facing economic hardships. The platform enables users to locate places offering free essential services like food, clothing, and shelter on an interactive map. Users can also contribute by adding and editing locations to ensure the information remains up-to-date.
 
-This project is built with [Nuxt 3](https://nuxt.com/), uses [Mapbox](https://www.mapbox.com/) for interactive mapping, and integrates [Supabase](https://supabase.com/) for backend services and data management.
+This project is built with [Nuxt 4](https://nuxt.com/), uses [Mapbox](https://www.mapbox.com/) for interactive mapping, and integrates [Supabase](https://supabase.com/) for backend services and data management.
 
 ## Features
 
 - **Interactive Map**: Visualize locations providing free services using Mapbox.
 - **User Contributions**: Users can add and edit locations to keep the map current.
 - **Real-time Data**: Powered by Supabase for efficient data storage and retrieval.
-- **Responsive Design**: Built with Nuxt 3 for a seamless experience across devices.
+- **Responsive Design**: Built with Nuxt 4 and Tailwind CSS for a seamless experience across devices.
+- **Composable State Management**: Shared state handled via Nuxt's `useState` API.
 
 ## Tech Stack
 
-- **Frontend**: Nuxt 3 (Vue.js-based framework)
+- **Frontend**: Nuxt 4 (Vue 3-based framework)
+- **State Management**: Nuxt `useState` composables
 - **Mapping**: Mapbox for interactive and dynamic maps
 - **Backend**: Supabase for authentication, database, and real-time updates
 

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -1,18 +1,18 @@
 import type { Location } from '~~/types';
 import locationsData from '~~/data/locations.json';
 
-const allLocations = locationsData as Location[];
+const allLocations = useState<Location[]>('allLocations', () => locationsData as Location[]);
 
-const selected = ref<Location | null>(null);
-const searchQuery = ref('');
-const filterTypes = ref<string[]>([]);
-const filterOrgs = ref<string[]>([]);
+const selected = useState<Location | null>('selectedLocation', () => null);
+const searchQuery = useState('searchQuery', () => '');
+const filterTypes = useState<string[]>('filterTypes', () => []);
+const filterOrgs = useState<string[]>('filterOrgs', () => []);
 
-const types = computed(() => Array.from(new Set(allLocations.map(l => l.type))).sort());
-const organizations = computed(() => Array.from(new Set(allLocations.map(l => l.organization))).sort());
+const types = computed(() => Array.from(new Set(allLocations.value.map(l => l.type))).sort());
+const organizations = computed(() => Array.from(new Set(allLocations.value.map(l => l.organization))).sort());
 
 const locations = computed(() =>
-  allLocations.filter(l => {
+  allLocations.value.filter(l => {
     const query = searchQuery.value.toLowerCase();
     const matchesQuery = !query || [l.name, l.city, l.address, l.description].some(v => v.toLowerCase().includes(query));
     const matchesType = filterTypes.value.length === 0 || filterTypes.value.includes(l.type);

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -1,27 +1,27 @@
 import type { Location } from '~~/types';
 import locationsData from '~~/data/locations.json';
 
-const allLocations = useState<Location[]>('allLocations', () => locationsData as Location[]);
-
-const selected = useState<Location | null>('selectedLocation', () => null);
-const searchQuery = useState('searchQuery', () => '');
-const filterTypes = useState<string[]>('filterTypes', () => []);
-const filterOrgs = useState<string[]>('filterOrgs', () => []);
-
-const types = computed(() => Array.from(new Set(allLocations.value.map(l => l.type))).sort());
-const organizations = computed(() => Array.from(new Set(allLocations.value.map(l => l.organization))).sort());
-
-const locations = computed(() =>
-  allLocations.value.filter(l => {
-    const query = searchQuery.value.toLowerCase();
-    const matchesQuery = !query || [l.name, l.city, l.address, l.description].some(v => v.toLowerCase().includes(query));
-    const matchesType = filterTypes.value.length === 0 || filterTypes.value.includes(l.type);
-    const matchesOrg = filterOrgs.value.length === 0 || filterOrgs.value.includes(l.organization);
-    return matchesQuery && matchesType && matchesOrg;
-  })
-);
-
 export function useLocations() {
+  const allLocations = useState<Location[]>('allLocations', () => locationsData as Location[]);
+
+  const selected = useState<Location | null>('selectedLocation', () => null);
+  const searchQuery = useState('searchQuery', () => '');
+  const filterTypes = useState<string[]>('filterTypes', () => []);
+  const filterOrgs = useState<string[]>('filterOrgs', () => []);
+
+  const types = computed(() => Array.from(new Set(allLocations.value.map(l => l.type))).sort());
+  const organizations = computed(() => Array.from(new Set(allLocations.value.map(l => l.organization))).sort());
+
+  const locations = computed(() => {
+    const query = searchQuery.value.toLowerCase();
+    return allLocations.value.filter(l => {
+      const matchesQuery = !query || [l.name, l.city, l.address, l.description].some(v => v.toLowerCase().includes(query));
+      const matchesType = filterTypes.value.length === 0 || filterTypes.value.includes(l.type);
+      const matchesOrg = filterOrgs.value.length === 0 || filterOrgs.value.includes(l.organization);
+      return matchesQuery && matchesType && matchesOrg;
+    });
+  });
+
   function focus(location: Location) {
     selected.value = location;
     useMapbox('main-map', map => {

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -16,6 +16,10 @@ try {
 // Provide Vue's ref globally to match Nuxt auto-import behavior
 (globalThis as any).ref = ref;
 (globalThis as any).computed = computed;
+(globalThis as any).useState = (_key: string, init: any) => {
+  const value = typeof init === 'function' ? init() : init;
+  return ref(value);
+};
 
 const { useLocations } = await import('../app/composables/useLocations.ts');
 

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -2,7 +2,14 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { ref, computed } from 'vue';
+
+function ref<T>(value: T) {
+  return { value } as { value: T };
+}
+
+function computed<T>(getter: () => T) {
+  return { get value() { return getter(); } } as { readonly value: T };
+}
 
 // Ensure alias `~~` points to project root so imports in composables work
 const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
@@ -10,6 +17,7 @@ const aliasDir = path.join(rootDir, 'node_modules', '~~');
 try {
   fs.statSync(aliasDir);
 } catch {
+  fs.mkdirSync(path.dirname(aliasDir), { recursive: true });
   fs.symlinkSync(rootDir, aliasDir, 'dir');
 }
 


### PR DESCRIPTION
## Summary
- refactor `useLocations` composable to use Nuxt 4 `useState` for shared reactive data
- document Nuxt 4 usage and state handling in README
- adapt tests to stub `useState`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689a575a7eac8333980a05bdd768a62b