### PR TITLE
refactor: centralize location icons and types

### DIFF
--- a/app/components/MapView.vue
+++ b/app/components/MapView.vue
@@ -1,17 +1,8 @@
 <script setup lang="ts">
+import { iconFor } from '~~/utils/location-icons';
+
 const { locations, locateMe, focus } = useLocations();
 const emit = defineEmits(['open-menu']);
-
-const iconMap: Record<string, string> = {
-  health: '/icons/health.svg',
-  foodbank: '/icons/food.svg',
-  shelter: '/icons/shelter.svg',
-  community: '/icons/community.svg',
-};
-
-function iconFor(type: string) {
-  return iconMap[type] ?? '/icons/community.svg';
-}
 </script>
 
 <template>

--- a/app/composables/useLocations.ts
+++ b/app/composables/useLocations.ts
@@ -1,4 +1,4 @@
-import type { Location } from '~~/types';
+import type { Location, LocationType } from '~~/types';
 import locationsData from '~~/data/locations.json';
 
 export function useLocations() {
@@ -6,10 +6,12 @@ export function useLocations() {
 
   const selected = useState<Location | null>('selectedLocation', () => null);
   const searchQuery = useState('searchQuery', () => '');
-  const filterTypes = useState<string[]>('filterTypes', () => []);
+  const filterTypes = useState<LocationType[]>('filterTypes', () => []);
   const filterOrgs = useState<string[]>('filterOrgs', () => []);
 
-  const types = computed(() => Array.from(new Set(allLocations.value.map(l => l.type))).sort());
+  const types = computed<LocationType[]>(() =>
+    Array.from(new Set(allLocations.value.map(l => l.type))).sort()
+  );
   const organizations = computed(() => Array.from(new Set(allLocations.value.map(l => l.organization))).sort());
 
   const locations = computed(() => {

--- a/tests/useLocations.spec.ts
+++ b/tests/useLocations.spec.ts
@@ -46,7 +46,15 @@ test('focus sets selected and calls flyTo with location coordinates', () => {
   };
 
   const { selected, focus } = useLocations();
-  const location = { name: 'Test', description: '', city: '', coordinates: [1, 2] as [number, number], type: 'food', address: '', organization: '' };
+  const location = {
+    name: 'Test',
+    description: '',
+    city: '',
+    coordinates: [1, 2] as [number, number],
+    type: 'foodbank',
+    address: '',
+    organization: '',
+  };
 
   focus(location);
 
@@ -61,7 +69,15 @@ test('reset clears selected and calls flyTo with default center', () => {
   };
 
   const { selected, focus, reset } = useLocations();
-  const location = { name: 'Test', description: '', city: '', coordinates: [1, 2] as [number, number], type: 'food', address: '', organization: '' };
+  const location = {
+    name: 'Test',
+    description: '',
+    city: '',
+    coordinates: [1, 2] as [number, number],
+    type: 'foodbank',
+    address: '',
+    organization: '',
+  };
 
   focus(location);
   calls.length = 0; // clear previous flyTo call

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,8 +1,10 @@
+export type LocationType = 'community' | 'foodbank' | 'health' | 'shelter';
+
 export interface Location {
   name: string;
   description: string;
   organization: string;
-  type: string;
+  type: LocationType;
   address: string;
   city: string;
   coordinates: [number, number];

--- a/utils/location-icons.ts
+++ b/utils/location-icons.ts
@@ -1,0 +1,12 @@
+import type { LocationType } from '~~/types';
+
+export const locationIconMap: Record<LocationType, string> = {
+  health: '/icons/health.svg',
+  foodbank: '/icons/food.svg',
+  shelter: '/icons/shelter.svg',
+  community: '/icons/community.svg',
+};
+
+export function iconFor(type: LocationType): string {
+  return locationIconMap[type] ?? locationIconMap.community;
+}


### PR DESCRIPTION
## Summary
- add `LocationType` union and use it across the app
- extract marker icon mapping into reusable utility
- type location filters in `useLocations`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689ac0ccd0f483338499994137f3d7ad